### PR TITLE
Replace Higher Order Heroku link with Heroku blog

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ How to architect your Heroku projects...
 
 Blogs around the internet that often (or exclusively) write about Heroku...
 
-- `blog` [Higher Order Heroku](http://www.higherorderheroku.com/) — a blog about developing on Heroku.
+- `blog` [Heroku Blog](https://blog.heroku.com) — the official Heroku blog.
 
 
 ## <img width="21" height="21" src="images/deployment.png" /> Deployment


### PR DESCRIPTION
The Higher Order Heroku link http://www.higherorderheroku.com/ is dead and doesn't appear to have a successor.

Rather than remove the entire section, I've replaced it with a link to the Heroku corporate blog.